### PR TITLE
Add PitchPattern Check

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -35,6 +35,7 @@ import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitSlab;
 import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitStairs;
 import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitStatic;
 import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitTrapDoor;
+import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitTurtleEgg;
 import fr.neatmonster.nocheatplus.config.WorldConfigProvider;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
@@ -57,6 +58,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     private static final BukkitShapeModel MODEL_END_PORTAL_FRAME = new BukkitEndPortalFrame();
     private static final BukkitShapeModel MODEL_SEA_PICKLE = new BukkitSeaPickle();
     private static final BukkitShapeModel MODEL_COCOA = new BukkitCocoa();
+    private static final BukkitShapeModel MODEL_TURTLE_EGG = new BukkitTurtleEgg();
 
     // Blocks that have a different shape, based on how they have been placed.
     private static final BukkitShapeModel MODEL_SLAB = new BukkitSlab();
@@ -146,17 +148,22 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
 
         // TODO: Also consider removing flags (passable_x4 etc).
 
-        // Adjust flags for individual blocks.
+    	// Variables for repeated flags (Temporary flags, these should be fixed later so that they are not added here)
+    	final long headFlags = BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE;
+    	final long blockFix = BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE;
+    	// Adjust flags for individual blocks.
         BlockProperties.setBlockFlags(Material.CAULDRON, 
                 BlockFlags.SOLID_GROUND | BlockProperties.F_GROUND_HEIGHT 
                 | BlockProperties.F_MIN_HEIGHT4_1);
-        BlockProperties.setBlockFlags(Material.COCOA, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
-        BlockProperties.setBlockFlags(Material.CHORUS_PLANT, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
-        // For some odd reason, adding the flags to MaterialUtil.HEADS_WALL does not apply the flag. Adding the flags one by one here solves the issue.
-        BlockProperties.setBlockFlags(Material.CREEPER_WALL_HEAD, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
-        BlockProperties.setBlockFlags(Material.ZOMBIE_WALL_HEAD, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
-        BlockProperties.setBlockFlags(Material.PLAYER_WALL_HEAD, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
-        BlockProperties.setBlockFlags(Material.DRAGON_WALL_HEAD, BlockFlags.SOLID_GROUND | BlockProperties.F_XZ100 | BlockProperties.F_IGN_PASSABLE);
+        BlockProperties.setBlockFlags(Material.COCOA, blockFix);
+        BlockProperties.setBlockFlags(Material.TURTLE_EGG, BlockProperties.F_IGN_PASSABLE | BlockFlags.SOLID_GROUND | BlockProperties.F_GROUND | BlockProperties.F_XZ100);
+        BlockProperties.setBlockFlags(Material.CHORUS_PLANT, blockFix);
+        BlockProperties.setBlockFlags(Material.CREEPER_WALL_HEAD, headFlags);
+        BlockProperties.setBlockFlags(Material.ZOMBIE_WALL_HEAD, headFlags);
+        BlockProperties.setBlockFlags(Material.PLAYER_WALL_HEAD, headFlags);
+        BlockProperties.setBlockFlags(Material.DRAGON_WALL_HEAD, headFlags);
+        BlockProperties.setBlockFlags(Material.WITHER_SKELETON_WALL_SKULL, headFlags);
+        BlockProperties.setBlockFlags(Material.SKELETON_WALL_SKULL, headFlags);
 
         // Directly keep blocks as is.
         for (final Material mat : new Material[] {
@@ -255,6 +262,13 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
         // Flower pots.
         for (Material mat : MaterialUtil.FLOWER_POTS) {
             addModel(mat, MODEL_FLOWER_POT);
+        }
+        
+        // Turtle Eggs.
+        for (Material mat : new Material[] {
+        		Material.TURTLE_EGG
+        }) {
+        	addModel(mat, MODEL_TURTLE_EGG);
         }
         
         // Conduit

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -171,7 +171,12 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
                 BridgeMaterial.COBWEB,
                 Material.HOPPER,
                 BridgeMaterial.MOVING_PISTON,
-                Material.SNOW
+                Material.SNOW,
+                Material.CAKE,
+                Material.BEACON,
+                Material.LADDER,
+                Material.VINE,
+                Material.ANVIL
         }) {
             processedBlocks.add(mat);
         }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -176,7 +176,10 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
                 Material.BEACON,
                 Material.LADDER,
                 Material.VINE,
-                Material.ANVIL
+                Material.ANVIL,
+                Material.CHIPPED_ANVIL,
+                Material.DAMAGED_ANVIL,
+                Material.CHORUS_FLOWER
         }) {
             processedBlocks.add(mat);
         }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitTurtleEgg.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitTurtleEgg.java
@@ -1,0 +1,56 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.TurtleEgg;
+
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+
+public class BukkitTurtleEgg implements BukkitShapeModel {
+
+    @Override
+    public double[] getShape(final BlockCache blockCache, 
+            final World world, final int x, final int y, final int z) {
+        final Block block = world.getBlockAt(x, y, z);
+        final BlockState state = block.getState();
+        final BlockData blockData = state.getBlockData();
+
+        if (blockData instanceof TurtleEgg) {
+            final TurtleEgg egg = (TurtleEgg) blockData;
+            switch (egg.getEggs()) {
+                case 1: // .8125 0.0 .1875 max: .25 .4375 .75
+                    return new double[] {0.8125, 0.0, 0.1875, 0.25, 0.4375, 0.75};
+                case 2: // .9375 .0 .0625 max: 0.0625 .4375 .9375
+                case 3:
+                case 4:
+                    return new double[] {0.9375, 0.0, 0.0625, 0.0625, 0.4375, 0.9375};
+                default:
+                    break;
+            }
+        }
+        return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    }
+
+    @Override
+    public int getFakeData(final BlockCache blockCache, 
+            final World world, final int x, final int y, final int z) {
+        return 0;
+    }
+
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/CheckType.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/CheckType.java
@@ -78,6 +78,7 @@ public enum CheckType {
     FIGHT_FASTHEAL(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_FASTHEAL),
     FIGHT_GODMODE(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_GODMODE),
     FIGHT_NOSWING(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_NOSWING),
+    FIGHT_PITCHPATTERN(CheckTypeType.CHECK, FIGHT, null),
     FIGHT_REACH(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_REACH),
     FIGHT_SELFHIT(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_SELFHIT),
     FIGHT_SPEED(CheckTypeType.CHECK, FIGHT, Permissions.FIGHT_SPEED),

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
@@ -84,6 +84,12 @@ public class FightConfig extends ACheckConfig {
     public final boolean    speedImprobableFeedOnly;
     public final float      speedImprobableWeight;
     public final ActionList speedActions;
+    
+    public final float      pitchPatternLimit;
+    public final int        pitchPatternSample;
+    public final double     pitchPatternDiff;
+    public final float      pitchPatternGCD;
+    public final ActionList pitchPatternActions;
 
     public final ActionList wrongTurnActions;
 
@@ -158,6 +164,12 @@ public class FightConfig extends ACheckConfig {
         speedImprobableFeedOnly = config.getBoolean(ConfPaths.FIGHT_SPEED_IMPROBABLE_FEEDONLY);
         speedImprobableWeight = (float) config.getDouble(ConfPaths.FIGHT_SPEED_IMPROBABLE_WEIGHT);
         speedActions = config.getOptimizedActionList(ConfPaths.FIGHT_SPEED_ACTIONS, Permissions.FIGHT_SPEED);
+        
+        pitchPatternLimit = (float) config.getDouble(ConfPaths.FIGHT_PITCHPATTERN_LIMIT);
+        pitchPatternSample = config.getInt(ConfPaths.FIGHT_PITCHPATTERN_SAMPLE);
+        pitchPatternDiff = config.getDouble(ConfPaths.FIGHT_PITCHPATTERN_DIFF);
+        pitchPatternGCD = (float) config.getDouble(ConfPaths.FIGHT_PITCHPATTERN_DELTAGCD);
+        pitchPatternActions = config.getOptimizedActionList(ConfPaths.FIGHT_PITCHPATTERN_ACTIONS, Permissions.FIGHT);
 
         wrongTurnActions = config.getOptimizedActionList(ConfPaths.FIGHT_WRONGTURN_ACTIONS, 
                 CheckType.FIGHT_WRONGTURN.getPermission());

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightData.java
@@ -14,8 +14,12 @@
  */
 package fr.neatmonster.nocheatplus.checks.fight;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
 
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -44,6 +48,10 @@ public class FightData extends ACheckData implements IDataOnRemoveSubCheckData, 
     public double                  reachVL;
     public double                  speedVL;
     public double                  wrongTurnVL;
+    public double                  pitchPatternVL;
+    
+    HashMap<UUID, Float> lastDeltaPitchGCDs = new HashMap<UUID, Float>();
+    HashMap<UUID, List<Float>> deltaPitches = new HashMap<UUID, List<Float>>();
 
     // Shared
     public String lastWorld			= "";
@@ -55,6 +63,7 @@ public class FightData extends ACheckData implements IDataOnRemoveSubCheckData, 
     /** Attack penalty (close combat, ENTITY_ATTACK). */
     public final PenaltyTime attackPenalty = new PenaltyTime();
     public final PenaltyTime clicPatPenalty = new PenaltyTime();
+    public boolean loginExempt;
 
     /** The entity id  which might get counter-attacked. */
     public int thornsId = Integer.MIN_VALUE;
@@ -170,6 +179,8 @@ public class FightData extends ACheckData implements IDataOnRemoveSubCheckData, 
                     noSwingVL = 0;
                     // Not reset time, for leniency rather.
                     break;
+                case FIGHT_PITCHPATTERN:
+                	pitchPatternVL = 0;
                 case FIGHT_SELFHIT:
                     selfHitVL.clear(System.currentTimeMillis());
                     break;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import org.bukkit.Location;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Parrot;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
@@ -33,6 +32,7 @@ import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.event.player.PlayerAnimationEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.ItemStack;
 
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
@@ -105,6 +105,8 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
 
     /** The no swing check. */
     private final NoSwing     noSwing     = addCheck(new NoSwing());
+	
+    private final PitchPattern pitchPattern = addCheck(new PitchPattern());
     
     private final FightSync    FightSync  = addCheck(new FightSync());
 
@@ -901,7 +903,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
     	final Player player = e.getPlayer();
     	final FightData data = DataManager.getGenericInstance(player, FightData.class);
     	
-    	if (entity instanceof Parrot) {
+    	if (entity.getType().getEntityClass().getCanonicalName().endsWith("Parrot")) {
 	data.exemptArmSwing = true;
     	} else {
 	data.exemptArmSwing = false;
@@ -916,6 +918,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
     public void playerLeaves(final Player player) {
         final FightData data = DataManager.getGenericInstance(player, FightData.class);
         data.angleHits.clear();
+	data.loginExempt = true;
     }
 
     @EventHandler(ignoreCancelled = false, priority = EventPriority.MONITOR)
@@ -950,6 +953,17 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
     }
 		
 		
+	}
+	
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void pitchPattern(PlayerMoveEvent e) {
+		Player player = e.getPlayer();
+		final IPlayerData pData = DataManager.getPlayerData(player);
+		final FightConfig cc = pData.getGenericInstance(FightConfig.class);
+		final FightData data = DataManager.getGenericInstance(player, FightData.class);
+		float deltaPitch = e.getTo().getPitch() - e.getFrom().getPitch();
+		
+		pitchPattern.check(player, deltaPitch, cc, pData, data);
 	}
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/PitchPattern.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/PitchPattern.java
@@ -1,0 +1,95 @@
+package fr.neatmonster.nocheatplus.checks.fight;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+//import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.Check;
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.permissions.Permissions;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+
+public class PitchPattern extends Check {
+	
+	public PitchPattern() {
+		super(CheckType.FIGHT_PITCHPATTERN);
+	}
+  //private final List<String> tags = new LinkedList<String>();
+	
+  /*
+  *	This check attempts to find the GCD of the players pitch movements.
+  *	All mouse movements should be divisible by a constant defined by your
+  *	mouse sensivity. Therefore, if it changes drastically or has a very low
+  *	GCD (since the constant is being changed), the player is likely
+  *	cheating. This can also detect cheats that change the players pitch
+  *	as well. Such as scaffold, aimbot, legit/ghost aura, derp, etc.
+  *
+  */
+  public void check(final Player player, final float deltaPitch, final FightConfig cc, final IPlayerData pData, final FightData data) {
+    UUID uuid = player.getUniqueId();
+    List<Float> lastDeltaPitches = data.deltaPitches.getOrDefault(uuid, new ArrayList());
+
+        // Don't include it in the sample if their pitch didn't change or
+        // their pitch is above the limit.
+        if(deltaPitch != 0 && Math.abs(deltaPitch) <= cc.pitchPatternLimit) {
+            lastDeltaPitches.add(Math.abs(deltaPitch));
+        }
+
+        // Samples of the pitch changes are at or bigger than the sample
+        if(lastDeltaPitches.size() >= cc.pitchPatternSample) {
+            float deltaPitchGCD = roundedGCD(lastDeltaPitches);
+            float lastDeltaPitchGCD = data.lastDeltaPitchGCDs.getOrDefault(uuid, deltaPitchGCD);
+            float gcdDiff = Math.abs(deltaPitchGCD - lastDeltaPitchGCD);
+
+            // Pitch GCD is a lot different from last time or the GCD is just too small
+            if((gcdDiff > cc.pitchPatternDiff || deltaPitchGCD < cc.pitchPatternGCD) & !data.loginExempt) {
+                executeActions(player, data.pitchPatternVL, 1D, pData.getGenericInstance(FightConfig.class).pitchPatternActions).willCancel();
+                data.pitchPatternVL += 1;
+            }
+            else {
+            data.pitchPatternVL *= 0.98;
+            data.loginExempt = false;
+            }
+
+            lastDeltaPitches.clear();
+            //tags.clear();
+            data.lastDeltaPitchGCDs.put(uuid, deltaPitchGCD);
+        }
+
+        data.deltaPitches.put(uuid, lastDeltaPitches);
+	}
+	
+  public static float roundedGCD(float x, float y) {
+      if(x == 0) {
+        return y;
+      }
+        
+      int quotient = getQuotient(y, x);
+      float remainder = ((y / x) - quotient) * x;
+      if(Math.abs(remainder) < Math.max(x, y) * 1E-3F) {
+      remainder = 0;	
+      }
+      return roundedGCD(remainder, x);
+    }
+
+    public static float roundedGCD(List<Float> values) {
+        float answer = values.get(0);
+        for (int i = 1; i < values.size(); i++) {
+            answer = roundedGCD(values.get(i), answer);
+        }
+        return answer;
+    }
+
+    public static int getQuotient(float dividend, float divisor) {
+        float answer = dividend / divisor;
+        float error = Math.max(dividend, divisor) * 1E-3F;
+        return (int)(answer + error);
+    }
+		
+
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryMove.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryMove.java
@@ -1,43 +1,95 @@
 package fr.neatmonster.nocheatplus.checks.inventory;
 
-import org.bukkit.GameMode;
-import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryType.SlotType;
+import java.util.LinkedList;
+import java.util.List;
 
+import org.bukkit.GameMode;
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.entity.Player;
+
+
+import fr.neatmonster.nocheatplus.actions.ParameterName;
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.utilities.StringUtil;
 
 /**
  * A simple check to prevent players from interacting with their inventory if they shouldn't be allowed to.
  */
+
 public class InventoryMove extends Check {
+	
+	private final List<String> tags = new LinkedList<String>();
 	
 	public InventoryMove() {
         super(CheckType.INVENTORY_MOVE);
     }
 	
-	public boolean check(final Player player, final InventoryData data, final IPlayerData pData, final InventoryConfig cc, final SlotType type) {
+    public boolean check(final Player player, final InventoryData data, final IPlayerData pData, final InventoryConfig cc, final SlotType type) {
 		
-		boolean cancel = false;
-		if (player.isBlocking() || player.isSprinting() || player.isDead() || player.isSneaking() || player.isSwimming()) {
-			if (player.getGameMode() == GameMode.CREATIVE) {
-			if (!cc.invMoveDisableCreative) {
-				if (type == SlotType.QUICKBAR) {
-					return false;
-				} else {
-				  data.invMoveVL += 1D;
-				  cancel = executeActions(player, data.invMoveVL, 1D, pData.getGenericInstance(InventoryConfig.class).invMoveActionList).willCancel();
-				}
-			} else {
-			  return false;
-			}
-			} else {
-			data.invMoveVL += 1D;
-			cancel = executeActions(player, data.invMoveVL, 1D, pData.getGenericInstance(InventoryConfig.class).invMoveActionList).willCancel();	
-			}
-		}
-		return cancel;
-	}
-	
-}
+    boolean cancel = false;
+    
+    // Tags 
+    if (player.isBlocking()) {
+    	tags.add("isBlocking");
+    }
+    else if (player.isSneaking()) {
+    	tags.add("isSneaking");
+    }
+    else if (player.isSwimming()) {
+    	tags.add("isSwimming");
+    }
+    else if (player.isSprinting()) {
+    	tags.add("isSprinting");
+    }
+    else if (player.isDead()) {
+    	tags.add("isDead");
+    }
+    
+     // Do the actual check 
+     if (player.isSneaking() || player.isSprinting() || player.isSwimming() || player.isBlocking() || player.isDead()) {
+           // Check if the player is in creative
+   	   if (player.getGameMode() == GameMode.CREATIVE) {
+   		   // (Skip hotbar interactions)
+   		   if (type == SlotType.QUICKBAR) {
+			// Prevent tag addition/spam
+			tags.clear();
+   		    	return false; 
+   		   }
+   	           // Check if the Disable_Creative option is not enabled
+   		   else if (!cc.invMoveDisableCreative) {
+   		       // Violation
+    	                data.invMoveVL += 1.0D;
+	                final ViolationData vd = new ViolationData(this, player, data.invMoveVL, 1, pData.getGenericInstance(InventoryConfig.class).invMoveActionList);
+	                if (vd.needsParameters()){
+	                  vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+	                }
+	             // Clear tags
+	             tags.clear();
+	             return executeActions(vd).willCancel();
+                   }
+   		   // Disable_Creative is enabled, skip
+   		   else {
+		     // Prevent tag addition/spam
+	             tags.clear();
+   	             return false;
+   		   }
+   	   }
+   	   // Player is not in creative
+   	   else {
+   	      // Violation
+	      data.invMoveVL += 1.0D;
+              final ViolationData vd = new ViolationData(this, player, data.invMoveVL, 1, pData.getGenericInstance(InventoryConfig.class).invMoveActionList);
+              if (vd.needsParameters()){
+                  vd.setParameter(ParameterName.TAGS, StringUtil.join(tags, "+"));
+              }
+           // Clear tags
+           tags.clear();
+           return executeActions(vd).willCancel();
+        }  
+      }
+      return cancel;
+   }
+ }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -1927,7 +1927,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             // Adjust fall distance, if set so.
             // TODO: How to account for plugins that reset the fall distance here?
             // TODO: Detect transition from valid flying that needs resetting the fall distance.
-            if (event.getCause() == TeleportCause.UNKNOWN) {
+            if (event.getCause() == TeleportCause.UNKNOWN || event.getCause() == TeleportCause.COMMAND) {
                 // Always keep fall damage.
                 player.setFallDistance((float) fallDistance);
                 data.noFallFallDistance = (float) fallDistance;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -433,7 +433,7 @@ public class SurvivalFly extends Check {
             }
 
             // Prevent players from sprinting if they're moving backwards (allow buffers to cover up !?).
-            if (sprinting && data.lostSprintCount == 0 && !cc.assumeSprint && hDistance > thisMove.walkSpeed && !data.hasActiveHorVel()) {
+            if (sprinting && data.lostSprintCount == 0 && hDistance > thisMove.walkSpeed && !data.hasActiveHorVel() && !player.hasPotionEffect(PotionEffectType.SPEED)) {
                 // (Ignore some cases, in order to prevent false positives.)
                 // TODO: speed effects ?
                 if (TrigUtil.isMovingBackwards(xDistance, zDistance, from.getYaw()) 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -490,6 +490,7 @@ public abstract class ConfPaths {
     public static final String  FIGHT_CLICKPATTERN_PENALTY               = FIGHT_CLICKPATTERN + "penalty";
     public static final String  FIGHT_CLICKPATTERN_ACTIONS               = FIGHT_CLICKPATTERN + "actions";
     
+
     private static final String FIGHT_CRITICAL                           = FIGHT + "critical.";
     public static final String  FIGHT_CRITICAL_CHECK                     = FIGHT_CRITICAL + SUB_ACTIVE;
     // TODO: Deprecate or rename (->falldistancemin)?
@@ -517,7 +518,15 @@ public abstract class ConfPaths {
     private static final String FIGHT_NOSWING                            = FIGHT + "noswing.";
     public static final String  FIGHT_NOSWING_CHECK                      = FIGHT_NOSWING + SUB_ACTIVE;
     public static final String  FIGHT_NOSWING_ACTIONS                    = FIGHT_NOSWING + "actions";
-
+    
+    private static final String FIGHT_PITCHPATTERN                       = FIGHT + "pitchpattern.";
+    public static final String  FIGHT_PITCHPATTERN_CHECK                 = FIGHT_PITCHPATTERN + SUB_ACTIVE;
+    public static final String  FIGHT_PITCHPATTERN_LIMIT                 = FIGHT_PITCHPATTERN + "limit";
+    public static final String  FIGHT_PITCHPATTERN_SAMPLE                = FIGHT_PITCHPATTERN + "sample";
+    public static final String  FIGHT_PITCHPATTERN_DIFF                  = FIGHT_PITCHPATTERN + "gcdDiff";
+    public static final String  FIGHT_PITCHPATTERN_DELTAGCD              = FIGHT_PITCHPATTERN + "deltaGCD";
+    public static final String  FIGHT_PITCHPATTERN_ACTIONS               = FIGHT_PITCHPATTERN + "actions";
+ 
     private static final String FIGHT_REACH                              = FIGHT + "reach.";
     public static final String  FIGHT_REACH_CHECK                        = FIGHT_REACH + SUB_ACTIVE;
     public static final String  FIGHT_REACH_SURVIVALDISTANCE             = FIGHT_REACH + "survivaldistance";
@@ -571,7 +580,7 @@ public abstract class ConfPaths {
 
     private static final String INVENTORY_FASTCLICK                      = INVENTORY + "fastclick.";
     public static final String  INVENTORY_FASTCLICK_CHECK                = INVENTORY_FASTCLICK + SUB_ACTIVE;
-    public static final String  INVENTORY_FASTCLICK_EXCLUDE              = INVENTORY_FASTCLICK + "exclude";
+    public static final String INVENTORY_FASTCLICK_EXCLUDE               = INVENTORY_FASTCLICK + "exclude";
     public static final String  INVENTORY_FASTCLICK_SPARECREATIVE        = INVENTORY_FASTCLICK + "sparecreative";
     public static final String  INVENTORY_FASTCLICK_TWEAKS1_5            = INVENTORY_FASTCLICK + "tweaks1_5";
     private static final String INVENTORY_FASTCLICK_LIMIT                = INVENTORY_FASTCLICK + "limit.";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -370,6 +370,13 @@ public class DefaultConfig extends ConfigFile {
 
         set(ConfPaths.FIGHT_NOSWING_CHECK, "default", 785);
         set(ConfPaths.FIGHT_NOSWING_ACTIONS, "cancel vl>10 log:noswing:0:5:if cancel", 785);
+        
+        set(ConfPaths.FIGHT_PITCHPATTERN_CHECK, "default", 1153);
+        set(ConfPaths.FIGHT_PITCHPATTERN_LIMIT, 20, 1153);
+        set(ConfPaths.FIGHT_PITCHPATTERN_SAMPLE, 10F, 1153);
+        set(ConfPaths.FIGHT_PITCHPATTERN_DIFF, 0.001D, 1153);
+        set(ConfPaths.FIGHT_PITCHPATTERN_DELTAGCD, 0.00001F, 1153);
+        set(ConfPaths.FIGHT_PITCHPATTERN_ACTIONS, "vl>2 log:pitchpattern:0:4:if", 1153);
 
         set(ConfPaths.FIGHT_REACH_CHECK, "default", 785);
         set(ConfPaths.FIGHT_REACH_SURVIVALDISTANCE, 4.4, 785);
@@ -691,6 +698,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".msgtempdenylogin", "You are temporarily denied to join this server.", 785);
         set(ConfPaths.STRINGS + ".munchhausen", start + "almost made it off the pit" + end, 785);
         set(ConfPaths.STRINGS + ".nofall", start + "tried to alter fall damage ([tags])" + end, 1057);
+        set(ConfPaths.STRINGS + ".pitchpattern", start + "inconsistent pitch patterns" + end, 1153);
         set(ConfPaths.STRINGS + ".chatfast", start + "acted like spamming (IP: [ip])" + end, 785);
         set(ConfPaths.STRINGS + ".noswing", start + "didn't swing arm" + end, 785);
         set(ConfPaths.STRINGS + ".passable", start + "moved into a block ([blocktype]) from [locationfrom] to [locationto] distance [distance] " + end, 785);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -722,92 +722,6 @@ public class DefaultConfig extends ConfigFile {
                 )) {
             set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + name, "default+ign_passable+ground_height", 785);
         }
-        for (final String woodtype : Arrays.asList(
-                "OAK",
-                "SPRUCE",
-                "BIRCH",
-                "JUNGLE",
-                "ACACIA",
-                "DARK_OAK"
-                )) { 
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + woodtype + "_FENCE", "HEIGHT150+THICK_FENCE+VARIABLE+ground", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "NETHER_BRICK_FENCE", "HEIGHT150+THICK_FENCE+VARIABLE+ground", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + woodtype + "_FENCE_GATE", "PASSABLE_X4+VARIABLE_USE+HEIGHT150+THICK_FENCE+VARIABLE+ground", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + woodtype + "_DOOR", "PASSABLE_X4+VARIABLE_USE+ground", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "IRON_DOOR", "PASSABLE_X4+VARIABLE_USE+ground", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + woodtype + "_SLAB", "default+GROUND+XZ100+ground_height", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + woodtype + "_TRAPDOOR", "default+ign_passable+ground_height", 1154);
-            set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "IRON_TRAPDOOR", "default+ign_passable+ground_height", 1154);
-        } for (final String colors : Arrays.asList(
-                "WHITE",
-                "BLUE",
-                "RED",
-                "MAGENTA",
-                "LIME",
-                "YELLOW",
-                "PINK",
-                "GRAY", 
-                "BROWN",
-                "GREEN",
-                "LIGHT_BLUE",
-                "CYAN",
-                "PURPLE",
-                "BLACK",
-                "LIGHT_GRAY",
-                "ORANGE"
-                )) { 
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + colors + "_BED", "default+ground_height", 1154);
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + colors + "_STAINED_GLASS_PANE", "THIN_FENCE+VARIABLE+ground_height+ground", 1154);
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + colors + "_SHULKER_BOX", "default+HEIGHT150+ground", 1154);
-        } for (final String headType : Arrays.asList(
-                "ZOMBIE",
-                "PLAYER",
-                "CREEPER",
-                "DRAGON"
-                )) { 
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + headType + "_HEAD", "solid+ground_height+ground+ground+ign_passable", 1154);
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "SKELETON_SKULL", "solid+ground_height+ground+ground+ign_passable", 1154);
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "WITHER_SKELETON_WALL_SKULL", "solid+ground_height+ground+ground+ign_passable", 1154);
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + headType + "_WALL_HEAD", "solid+ground_height+ground+ground+ign_passable", 1154);
-        } for (final String slabType : Arrays.asList(
-                "STONE",
-                "SANDSTONE",
-                "PETRIFIED_OAK",
-                "COBBLESTONE",
-                "BRICK",
-                "STONE_BRICK",
-                "NETHER_BRICK",
-                "QUARTZ",
-                "RED_SANDSTONE",
-                "PURPUR",
-                "PRISMARINE",
-                "PRISMARINE_BRICK",
-                "DARK_PRISMARINE"
-                )) { 
-        	set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + slabType + "_SLAB", "default+GROUND+XZ100+ground_height", 1154);
-        }
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "MAGMA_BLOCK", "default+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "LILY_PAD", "default+ign_passable+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "END_ROD", "default+ign_passable", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "IRON_BARS", "THIN_FENCE+VARIABLE+ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "GLASS_PANE", "THIN_FENCE+VARIABLE+ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "COBBLESTONE_WALL", "HEIGHT150+VARIABLE+THICK_FENCE+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "MOSSY_COBBLESTONE_WALL", "HEIGHT150+VARIABLE+THICK_FENCE+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "ANVIL", "default+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "DAMAGED_ANVIL", "default+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "CHIPPED_ANVIL", "default+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "GRASS_PATH", "default+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "SHULKER_BOX", "default+HEIGHT150+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "CHEST", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "TRAPPED_CHEST", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "ENDER_CHEST", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "FARMLAND", "default+height100+ground_height+min_height16_15", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "TURTLE_EGG", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "SEA_PICKLE", "default+ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "CAULDRON", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "CONDUIT", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "FLOWER_POT", "ground_height+ground", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "ENCHANTING_TABLE", "ground_height+ground", 1154);
         for (final String DeadCoralType : Arrays.asList(
                 "DEAD_TUBE",
                 "DEAD_BRAIN",
@@ -821,12 +735,6 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "DEAD_TUBE_CORAL_FAN", "default+ign_passable+ground_height", 1154);
         set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "DEAD_BRAIN_CORAL_FAN", "default+ign_passable+ground_height", 1154);
         set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "DEAD_BUBBLE_CORAL_FAN", "default+ign_passable+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "DAYLIGHT_DETECTOR", "default+GROUND+XZ100+ground_height", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "BLUE_ICE", "default+ground_height+allow_lowjump+ice", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "END_PORTAL_FRAME", "default+ign_passable+ground_height+ALLOW_LOWJUMP", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "COCOA", "default+ign_passable+ground_height+ALLOW_LOWJUMP", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "REPEATER", "default+ign_passable+ground_height+ALLOW_LOWJUMP", 1154);
-        set(ConfPaths.COMPATIBILITY_BLOCKS + ConfPaths.SUB_OVERRIDEFLAGS + "." + "COMPARATOR", "default+ign_passable+ground_height+ALLOW_LOWJUMP", 1154);
         set(ConfPaths.COMPATIBILITY_BLOCKS_CHANGETRACKER_ACTIVE, true, 1036); // With lastChangedBuildNumber.
         set(ConfPaths.COMPATIBILITY_BLOCKS_CHANGETRACKER_PISTONS, true, 785);
         set(ConfPaths.COMPATIBILITY_BLOCKS_CHANGETRACKER_MAXAGETICKS, 80, 785);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -623,7 +623,7 @@ public class DefaultConfig extends ConfigFile {
         final String start = "[player] failed [check]: ";
         final String end = ". VL [violations].";
         final String tell = "ncp tell [player] ";
-        set(ConfPaths.STRINGS + ".angle", start + "tried to hit multiple entities at the same time" + end, 785);
+        set(ConfPaths.STRINGS + ".angle", start + "tried to hit multiple entities at the same time (Tags [tags])" + end, 785);
         set(ConfPaths.STRINGS + ".attackfrequency", start + "attacks with too high a frequency ([packets]/[limit], [tags])" + end, 785);
         set(ConfPaths.STRINGS + ".ban", "ban [player]", 785);
         set(ConfPaths.STRINGS + ".ban-ip", "ban-ip [ip]", 785);
@@ -638,6 +638,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".bwrong", start + "broke another block than clicked" + end, 785);
         set(ConfPaths.STRINGS + ".captcha", "[player] failed captcha repeatedly" + end, 785);
         set(ConfPaths.STRINGS + ".chatnormal", start + "potentially annoying chat" + end, 785);
+        set(ConfPaths.STRINGS + ".clickpat", start + " seems to be clicking with bot-like frequencies" + end, 785);
         set(ConfPaths.STRINGS + ".color", start + "sent colored chat message" + end, 785);
         set(ConfPaths.STRINGS + ".commands", start + "issued too many commands" + end, 785);
         set(ConfPaths.STRINGS + ".critical", start + "tried to do a critical hit but wasn't technically jumping [tags]" + end, 785);
@@ -663,7 +664,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.STRINGS + ".improbable", start + "meets the improbable more than expected" + end, 785);
         set(ConfPaths.STRINGS + ".instantbow", start + "fires bow too fast" + end, 785);
         set(ConfPaths.STRINGS + ".instanteat", start + "eats food [food] too fast" + end, 785);
-        set(ConfPaths.STRINGS + ".inventorymove", start + "interacted with inventory while it was not possible" + end, 1153);
+        set(ConfPaths.STRINGS + ".inventorymove", start + "interacted with inventory while it was not possible (tags [tags])" + end, 1153);
         set(ConfPaths.STRINGS + ".keepalive", start + "spams keep-alive packets (god/freecam?)" + end, 785);
         set(ConfPaths.STRINGS + ".kick", "kick [player]", 785);
         set(ConfPaths.STRINGS + ".kickalive", "ncp kick [player] Too many keep-alive packets.", 785);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -1208,6 +1208,7 @@ public class BlockProperties {
                 BridgeMaterial.END_PORTAL_FRAME,
                 // XZ-bounds issues.
                 BridgeMaterial.CAKE,
+		BridgeMaterial.get("ANVIL"),
                 // Already worked around with isPassableWorkaround (kept for dev-reference).
                 //				Material.ANVIL,
                 //				Material.SKULL, Material.FLOWER_POT,


### PR DESCRIPTION
This check attempts to find the GCD of the players pitch movements. All mouse movements should be divisible by a constant defined by your mouse sensitivity. Therefore, if it changes drastically or has a very low GCD (since the constant is being changed), the player is likely
cheating. This can also detect cheats that change the players pitch as well. Such as scaffold, aimbot, legit/ghost aura, derp, etc.